### PR TITLE
feat: revert on receiveInbound connector unavailable

### DIFF
--- a/src/Controller.sol
+++ b/src/Controller.sol
@@ -145,8 +145,10 @@ contract Controller is IHub, Gauge, Ownable2Step {
     }
 
     // receive inbound assuming connector called
-    // if connector is not configured (malicious), its mint amount will forever stay in pending
     function receiveInbound(bytes memory payload_) external override {
+        if (_mintLimitParams[msg.sender].maxLimit == 0)
+            revert ConnectorUnavailable();
+
         (address receiver, uint256 lockAmount) = abi.decode(
             payload_,
             (address, uint256)

--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -126,8 +126,10 @@ contract Vault is Gauge, IHub, Ownable2Step {
     }
 
     // receive inbound assuming connector called
-    // if connector is not configured (malicious), its unlock amount will forever stay in pending
     function receiveInbound(bytes memory payload_) external override {
+        if (_unlockLimitParams[msg.sender].maxLimit == 0)
+            revert ConnectorUnavailable();
+
         (address receiver, uint256 unlockAmount) = abi.decode(
             payload_,
             (address, uint256)

--- a/test/Controller.t.sol
+++ b/test/Controller.t.sol
@@ -304,53 +304,11 @@ contract TestController is Test {
     function testReceiveInboundConnectorUnavail() external {
         _setLimits();
         uint256 depositAmount = 2 ether;
+        deal(address(_token), address(_controller), depositAmount, true);
 
-        uint256 totalMintedBefore = _controller.totalMinted();
-        uint256 rajuBalBefore = _token.balanceOf(_raju);
-        uint256 pendingMintsBefore = _controller.pendingMints(
-            _wrongConnector,
-            _raju
-        );
-        uint256 connectorPendingMintsBefore = _controller.connectorPendingMints(
-            _wrongConnector
-        );
-        uint256 connectorLockedBefore = _controller.connectorLockedAmounts(
-            _wrongConnector
-        );
-
+        vm.expectRevert(Controller.ConnectorUnavailable.selector);
         vm.prank(_wrongConnector);
         _controller.receiveInbound(abi.encode(_raju, depositAmount));
-
-        uint256 totalMintedAfter = _controller.totalMinted();
-        uint256 rajuBalAfter = _token.balanceOf(_raju);
-        uint256 pendingMintsAfter = _controller.pendingMints(
-            _wrongConnector,
-            _raju
-        );
-        uint256 connectorPendingMintsAfter = _controller.connectorPendingMints(
-            _wrongConnector
-        );
-        uint256 connectorLockedAfter = _controller.connectorLockedAmounts(
-            _wrongConnector
-        );
-
-        assertEq(totalMintedAfter, totalMintedBefore, "total minted sus");
-        assertEq(rajuBalAfter, rajuBalBefore, "raju balance sus");
-        assertEq(
-            pendingMintsAfter,
-            pendingMintsBefore + depositAmount,
-            "pending mints sus"
-        );
-        assertEq(
-            connectorPendingMintsAfter,
-            connectorPendingMintsBefore + depositAmount,
-            "total pending amount sus"
-        );
-        assertEq(
-            connectorLockedAfter,
-            connectorLockedBefore + depositAmount,
-            "connector locked amount sus"
-        );
     }
 
     function testFullConsumeInboundReceive() external {
@@ -532,17 +490,6 @@ contract TestController is Test {
         _setLimits();
         uint256 depositAmount = 2 ether;
         deal(address(_token), address(_controller), depositAmount, true);
-
-        vm.prank(_wrongConnector);
-        _controller.receiveInbound(abi.encode(_raju, depositAmount));
-
-        uint256 pendingMints = _controller.pendingMints(_wrongConnector, _raju);
-        uint256 connectorPendingMints = _controller.connectorPendingMints(
-            _wrongConnector
-        );
-
-        assertEq(pendingMints, depositAmount);
-        assertEq(connectorPendingMints, depositAmount);
 
         vm.expectRevert(Controller.ConnectorUnavailable.selector);
         _controller.mintPendingFor(_raju, _wrongConnector);

--- a/test/Vault.t.sol
+++ b/test/Vault.t.sol
@@ -287,41 +287,9 @@ contract TestVault is Test {
         uint256 withdrawAmount = 2 ether;
         deal(address(_token), address(_vault), withdrawAmount);
 
-        uint256 vaultBalBefore = _token.balanceOf(address(_vault));
-        uint256 rajuBalBefore = _token.balanceOf(_raju);
-        uint256 pendingUnlocksBefore = _vault.pendingUnlocks(
-            _wrongConnector,
-            _raju
-        );
-        uint256 connectorPendingUnlocksBefore = _vault.connectorPendingUnlocks(
-            _wrongConnector
-        );
-
+        vm.expectRevert(Vault.ConnectorUnavailable.selector);
         vm.prank(_wrongConnector);
         _vault.receiveInbound(abi.encode(_raju, withdrawAmount));
-
-        uint256 vaultBalAfter = _token.balanceOf(address(_vault));
-        uint256 rajuBalAfter = _token.balanceOf(_raju);
-        uint256 pendingUnlocksAfter = _vault.pendingUnlocks(
-            _wrongConnector,
-            _raju
-        );
-        uint256 connectorPendingUnlocksAfter = _vault.connectorPendingUnlocks(
-            _wrongConnector
-        );
-
-        assertEq(vaultBalAfter, vaultBalBefore, "vault balance sus");
-        assertEq(rajuBalAfter, rajuBalBefore, "raju balance sus");
-        assertEq(
-            pendingUnlocksAfter,
-            pendingUnlocksBefore + withdrawAmount,
-            "pending unlocks sus"
-        );
-        assertEq(
-            connectorPendingUnlocksAfter,
-            connectorPendingUnlocksBefore + withdrawAmount,
-            "total pending amount sus"
-        );
     }
 
     function testFullConsumeInboundReceive() external {
@@ -479,17 +447,6 @@ contract TestVault is Test {
         _setLimits();
         uint256 withdrawAmount = 2 ether;
         deal(address(_token), address(_vault), withdrawAmount);
-
-        vm.prank(_wrongConnector);
-        _vault.receiveInbound(abi.encode(_raju, withdrawAmount));
-
-        uint256 pendingUnlocks = _vault.pendingUnlocks(_wrongConnector, _raju);
-        uint256 connectorPendingUnlocks = _vault.connectorPendingUnlocks(
-            _wrongConnector
-        );
-
-        assertEq(pendingUnlocks, withdrawAmount);
-        assertEq(connectorPendingUnlocks, withdrawAmount);
 
         vm.expectRevert(Vault.ConnectorUnavailable.selector);
         _vault.unlockPendingFor(_raju, _wrongConnector);


### PR DESCRIPTION
SOC-6 reported in audit.
Explicit revert in receiveInbound function when connector is not configured.